### PR TITLE
use setTagsContext() instead of setExtraContext()

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -74,7 +74,7 @@ function createLogger(serviceName, envTags) {
 
   if (sentryDSN) {
     client = new raven.Client(sentryDSN, {logger: serviceName});
-    client.setExtraContext(envTags)
+    client.setTagsContext(envTags)
     log('logging errors to sentry, envTags: ' + JSON.stringify(envTags));
   } else {
     log('not logging errors to sentry');


### PR DESCRIPTION
##### WHAT

switch api call for adding envTags to sentry errors

##### WHY

puts the tags in a better place in the sentry error report, allows filtering, etc

##### WHO

@darend 
cc @rzlee @gerad 