### PR TITLE
fix crash - set the sentry release the correct way

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -73,9 +73,11 @@ function createLogger(serviceName, release, envTags) {
   log.logger = logger;
 
   if (sentryDSN) {
-    client = new raven.Client(sentryDSN, {logger: serviceName});
+    client = new raven.Client(sentryDSN, {
+      logger: serviceName,
+      release: release
+    });
     client.setTagsContext(envTags);
-    client.setRelease(release);
     log('logging errors to sentry, envTags: ' + JSON.stringify(envTags));
   } else {
     log('not logging errors to sentry');


### PR DESCRIPTION
##### WHAT

https://docs.getsentry.com/hosted/clients/javascript/config/

- "Can also be defined with Raven.setRelease('721e41770371db95eee98ca2707686226b993eda')."

^^^ this is not the case apparently, so setting the release an alternate way

##### WHO

@darend @gerad 

