### PR TITLE
Improve uncaughtException output

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -35,6 +35,9 @@ class Logger {
 
   handleUncaughtException() {
     var uncaughtException = (meta, err) => {
+      if (this.consoleWriter.error) {
+        this.consoleWriter.error(err.stack);
+      }
       this.error('uncaught exception, exiting', meta, err);
       process.exit(1);
     };


### PR DESCRIPTION
## Before
![image](https://cloud.githubusercontent.com/assets/16573/15443814/0ff5cf02-1ea0-11e6-9b47-fcb8db04c1e6.png)

## After
![image](https://cloud.githubusercontent.com/assets/16573/15443826/1d037a5a-1ea0-11e6-9f68-eba94cb42326.png)

## Who
@rzlee @gerad @jeremymailen 

## Why
So errors during development are easier to read

## N.B.
This also means we'll be logging UNCAUGHT exceptions twice (once to stdout, one to sumo)