### PR TITLE
Async logging

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 4.2.5
+    version: 7.10.0

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "raven": "^0.10.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
+    "eslint": "^4.1.1",
     "jasmine": "^2.4.1"
   }
 }


### PR DESCRIPTION
## What
- add the capability to write log statements asynchronously at a given interval
- interval is specified in milliseconds as part of the opts parameter to the constructor
{
  intervalMs: 1000
}
- logger will continue to log synchronously if intervalMs is not specified or is 0 

## Why
- so that writing log messages to the console can be batched and scheduled on the event loop
- we hope to take advantage of this on the edge-broker which is heavily I/O bound; logging can potentially happen when there are "spare cycles" on the event loop while a lot of I/O is going on

## Who
@gerad 

## FYI
I did not make any logic changes to the existing tests (just had to change how variables were initialized); new tests are in "asynchronous logging"