### PR TITLE
Flush messages before exiting on uncaught exception

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -48,6 +48,7 @@ class Logger {
   handleUncaughtException() {
     var uncaughtException = (meta, err) => {
       this.error('uncaught exception, exiting', meta, err);
+      this.flush();
       process.exit(1);
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-logger",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Structured js logging",
   "main": "logger.js",
   "scripts": {

--- a/spec/logger_spec.js
+++ b/spec/logger_spec.js
@@ -148,6 +148,7 @@ describe('Logger', function() {
       });
 
       spyOn(this.subject, 'error');
+      spyOn(this.subject, 'flush');
 
       this.subject.handleUncaughtException();
     });
@@ -158,6 +159,10 @@ describe('Logger', function() {
 
     it('logs the error', function() {
       expect(this.subject.error).toHaveBeenCalledWith('uncaught exception, exiting', { sentrySent }, error);
+    });
+
+    it('flushes messages', function() {
+      expect(this.subject.flush).toHaveBeenCalled();
     });
 
     it('calls process.exit(1)', function() {


### PR DESCRIPTION
### WHAT
* add message flushing before exiting on uncaught exception

### WHY
* because otherwise we don't get any message for uncaught exceptions

before:
![screen shot 2017-08-04 at 2 27 03 pm](https://user-images.githubusercontent.com/1855325/28988362-5d864b90-7924-11e7-9571-0af6c3c40c67.png)

after:
![screen shot 2017-08-04 at 2 51 41 pm](https://user-images.githubusercontent.com/1855325/28988390-7bdc0b2a-7924-11e7-9970-aac62dae4abe.png)

### WHO
@malexovi 