### PR TITLE
Add ability to log critical level messages

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -13,7 +13,7 @@ class Logger {
       log(msg) {
         process.stdout.write(msg, 'utf8');
         process.stdout.write('\n');
-      }
+      },
     };
     this.consoleWriter = opts.consoleWriter || defaultConsoleWriter;
     this.sentryClient = opts.sentryClient || this._createSentryClient(serviceName, release, envTags);
@@ -35,14 +35,11 @@ class Logger {
   }
 
   error(message, meta, error) {
-    this._log('error', message, meta, error);
-    if (this.sentryClient) {
-      if (error) {
-        this.sentryClient.captureException(this._errorify(error), { extra: { meta, message } });
-      } else {
-        this.sentryClient.captureMessage(message, { extra: { meta } });
-      }
-    }
+    this._logWithSentry('error', message, meta, error);
+  }
+
+  critical(message, meta, error) {
+    this._logWithSentry('critical', message, meta, error);
   }
 
   handleUncaughtException() {
@@ -80,6 +77,17 @@ class Logger {
       this.logMessages.push(logMsg);
     } else {
       this._writeMessage(logMsg);
+    }
+  }
+
+  _logWithSentry(severity, message, meta, error) {
+    this._log(severity, message, meta, error);
+    if (this.sentryClient) {
+      if (error) {
+        this.sentryClient.captureException(this._errorify(error), { extra: { meta, message } });
+      } else {
+        this.sentryClient.captureMessage(message, { extra: { meta } });
+      }
     }
   }
 

--- a/spec/logger_spec.js
+++ b/spec/logger_spec.js
@@ -61,46 +61,51 @@ describe('Logger', function() {
       expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
     });
 
-    it('error logs', function() {
-      var testError = new Error('test');
-      this.subject.error(message, meta, testError);
-      this.expectedLogged.severity = 'error';
-      this.expectedLogged.meta = meta;
-      this.expectedLogged.error = {
-        message: testError.message,
-        stack: testError.stack,
-      };
-      var testLogMsgString = JSON.stringify(this.expectedLogged);
+    itHandlesLogsWithSentry('error');
+    itHandlesLogsWithSentry('critical');
 
-      expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
-      expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(testError);
-    });
+    function itHandlesLogsWithSentry(severity) {
+      it(`${severity} logs`, function() {
+        var testError = new Error('test');
+        this.subject[severity](message, meta, testError);
+        this.expectedLogged.severity = severity;
+        this.expectedLogged.meta = meta;
+        this.expectedLogged.error = {
+          message: testError.message,
+          stack: testError.stack,
+        };
+        var testLogMsgString = JSON.stringify(this.expectedLogged);
 
-    it('error logs with string', function() {
-      var testErrorStr = 'errorString';
-      this.subject.error(message, meta, testErrorStr);
-      this.expectedLogged.severity = 'error';
-      this.expectedLogged.meta = meta;
-      this.expectedLogged.error = testErrorStr;
-      var testLogMsgString = JSON.stringify(this.expectedLogged);
+        expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
+        expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(testError);
+      });
 
-      expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
-      expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(new Error(testErrorStr));
-    });
+      it(`${severity} logs with string`, function() {
+        var testErrorStr = 'errorString';
+        this.subject[severity](message, meta, testErrorStr);
+        this.expectedLogged.severity = severity;
+        this.expectedLogged.meta = meta;
+        this.expectedLogged.error = testErrorStr;
+        var testLogMsgString = JSON.stringify(this.expectedLogged);
 
-    it('error logs with object', function() {
-      var testErrorObj = { errorCode: '101', errorMessage: 'the end' };
-      this.subject.error(message, meta, testErrorObj);
-      this.expectedLogged.severity = 'error';
-      this.expectedLogged.meta = meta;
-      this.expectedLogged.error = testErrorObj;
-      var testLogMsgString = JSON.stringify(this.expectedLogged);
+        expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
+        expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(new Error(testErrorStr));
+      });
 
-      expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
-      expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(
-        new Error(JSON.stringify(testErrorObj))
-      );
-    });
+      it(`${severity} logs with object`, function() {
+        var testErrorObj = { errorCode: '101', errorMessage: 'the end' };
+        this.subject[severity](message, meta, testErrorObj);
+        this.expectedLogged.severity = severity;
+        this.expectedLogged.meta = meta;
+        this.expectedLogged.error = testErrorObj;
+        var testLogMsgString = JSON.stringify(this.expectedLogged);
+
+        expect(this.consoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
+        expect(this.sentrySpy.captureException.calls.mostRecent().args[0]).toEqual(
+          new Error(JSON.stringify(testErrorObj))
+        );
+      });
+    }
   });
 
   describe('asynchronous logging', function() {


### PR DESCRIPTION
**Why**
This allows us to take advantage of automatic paging from sumo when a critical error is logged