### PR TITLE
Fix issue where log.error was not going to sentry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
     "rules": {
+        "comma-dangle": ["warn", "always-multiline"],
         "indent": [
             2,
             2

--- a/jasmine.js
+++ b/jasmine.js
@@ -4,6 +4,6 @@ var jasmine = new Jasmine();
 
 jasmine.loadConfigFile('spec/support/jasmine.json');
 jasmine.configureDefaultReporter({
-  showColors: true
+  showColors: true,
 });
 jasmine.execute();

--- a/logger.js
+++ b/logger.js
@@ -121,6 +121,7 @@ class Logger {
     } else {
       this.log('not logging errors to sentry');
     }
+    return client;
   }
 
   _writeMessage(msg) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "raven": "^0.10.0"
   },
   "devDependencies": {
-    "eslint": "^4.1.1",
+    "eslint": "^4.18.2",
     "jasmine": "^2.4.1"
   }
 }

--- a/spec/logger_spec.js
+++ b/spec/logger_spec.js
@@ -192,4 +192,22 @@ describe('Logger', function() {
       expect(myConsoleSpy.log).toHaveBeenCalledWith(testLogMsgString);
     });
   });
+
+  describe('when SENTRY_DSN is in the env', function() {
+    beforeEach(function() {
+      this.prevSentryDSN = process.env.SENTRY_DSN;
+      process.env.SENTRY_DSN = 'https://test:test@sentry.io/12345';
+    });
+
+    afterEach(function() {
+      process.env.SENTRY_DSN = this.prevSentryDSN;
+    });
+
+    it('creates a sentry client', function() {
+      let logger = new Logger(testServiceName, testRelease, null, {
+        consoleWriter: this.consoleSpy,
+      });
+      expect(logger.sentryClient).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
The sentry client was being created by default, but it wasn't being used to log the errors to sentry.
    
**why**

This was causing us not to get the sentry notifications we were expecting for the errors in our services.

https://app.clubhouse.io/gladly/story/9230/edge-broker-is-not-reporting-to-sentry