### PR TITLE
RFC: Add ability to ignore logging based on levels

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 7.10.0


### PR DESCRIPTION
## What
Add log levels and the ability to ignore logging based on level

## Why
Because I don't want someone to have to re-implement logging in edge-broker in 6 months.

## Note
Untested