### PR TITLE
Update Sentry raven library

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -116,7 +116,7 @@ class Logger {
         logger: serviceName,
         release: release,
       });
-      client.setTagsContext(envTags);
+      client.setContext(envTags);
       this.log('logging errors to sentry', { envTags: envTags });
     } else {
       this.log('not logging errors to sentry');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "repository": "https://github.com/sagansystems/js-logger.git",
   "dependencies": {
-    "raven": "^0.10.0"
+    "raven": "^2.6.4"
   },
   "devDependencies": {
     "eslint": "^4.18.2",


### PR DESCRIPTION
Doing this so that we can have one raven version in edge-router.

**Why**
We were using older version, raven btw is getting deprecated, but should
still be supported for a while.

**Testing**
NMTN ? build passing