### PR TITLE
Update deprecated .patchGlobal

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -112,12 +112,13 @@ class Logger {
     var sentryDSN = process.env.SENTRY_DSN;
     var client;
     if (sentryDSN) {
-      client = new raven.Client(sentryDSN, {
+      client = raven.config(sentryDSN, {
         logger: serviceName,
         release: release,
       });
       client.setContext(envTags);
       this.log('logging errors to sentry', { envTags: envTags });
+      this.log(`client context: ${client.getContext()}`);
     } else {
       this.log('not logging errors to sentry');
     }

--- a/logger.js
+++ b/logger.js
@@ -115,8 +115,8 @@ class Logger {
       client = raven.config(sentryDSN, {
         logger: serviceName,
         release: release,
+        tags: envTags,
       });
-      client.setContext(envTags);
       this.log('logging errors to sentry', { envTags: envTags });
       this.log(`client context: ${client.getContext()}`);
     } else {

--- a/logger.js
+++ b/logger.js
@@ -118,7 +118,6 @@ class Logger {
         tags: envTags,
       });
       this.log('logging errors to sentry', { envTags: envTags });
-      this.log(`client context: ${client.getContext()}`);
     } else {
       this.log('not logging errors to sentry');
     }

--- a/logger.js
+++ b/logger.js
@@ -50,7 +50,7 @@ class Logger {
     };
 
     if (this.sentryClient) {
-      this.sentryClient.patchGlobal((sentrySent, err) => {
+      this.sentryClient.install((sentrySent, err) => {
         uncaughtException({ sentrySent }, err);
       });
     } else {

--- a/spec/logger_spec.js
+++ b/spec/logger_spec.js
@@ -19,7 +19,7 @@ describe('Logger', function() {
       message: message,
     };
     this.consoleSpy = jasmine.createSpyObj(['log']);
-    this.sentrySpy = jasmine.createSpyObj(['captureException', 'captureMessage', 'patchGlobal']);
+    this.sentrySpy = jasmine.createSpyObj(['captureException', 'captureMessage', 'install']);
   });
 
   afterEach(function() {
@@ -148,7 +148,7 @@ describe('Logger', function() {
 
       spyOn(process, 'exit');
 
-      this.sentrySpy.patchGlobal.and.callFake(callback => {
+      this.sentrySpy.install.and.callFake(callback => {
         callback(sentrySent, error);
       });
 
@@ -159,7 +159,7 @@ describe('Logger', function() {
     });
 
     it('patches for uncaught errors', function() {
-      expect(this.sentrySpy.patchGlobal).toHaveBeenCalled();
+      expect(this.sentrySpy.install).toHaveBeenCalled();
     });
 
     it('logs the error', function() {


### PR DESCRIPTION
**Why**
.patchGlobal was deprecated:
https://github.com/getsentry/sentry-javascript/blob/master/packages/raven-node/CHANGELOG.md#100---12122016

(fwiw looks like `new raven.Client(...)` was also deprecated.... but still works)

**Testing**
build passing, updated js-logger can be used in, say, edge-broker