### PR TITLE
Bump js-logger version - realized we have not bumped in 2 years or so

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-logger",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Structured js logging",
   "main": "logger.js",
   "scripts": {


### PR DESCRIPTION
**Why**
We did not bump in a while, but overall looks like is still backwards
compatible (no changes needed to logger in, say, edge-broker), so
bumping minor.

**Testing**
N/A